### PR TITLE
Bug Fix: 90 and 270 degree rotated furniture now have appropriate boundaries

### DIFF
--- a/client/src/URL.jsx
+++ b/client/src/URL.jsx
@@ -1,4 +1,4 @@
-// const URL = "http://localhost:3001"
-const URL = "https://mindful-journal-server.vercel.app"
+const URL = "http://localhost:3001"
+// const URL = "https://mindful-journal-server.vercel.app"
 
 export default URL;

--- a/client/src/URL.jsx
+++ b/client/src/URL.jsx
@@ -1,4 +1,4 @@
-const URL = "http://localhost:3001"
-// const URL = "https://mindful-journal-server.vercel.app"
+// const URL = "http://localhost:3001"
+const URL = "https://mindful-journal-server.vercel.app"
 
 export default URL;

--- a/client/src/components/SeatingChart/ClassroomFurniture.jsx
+++ b/client/src/components/SeatingChart/ClassroomFurniture.jsx
@@ -63,7 +63,7 @@ const ClassroomFurniture = ({
                 furniturePositions[item._id]?.rotation || item.rotation,
             }}
             drag
-            dragElastic={0.1}
+            dragElastic={0}
             dragPropagation={false}
             dragConstraints={dragConstraints}
             onDragStart={() => setIsDragging(true)}

--- a/client/src/components/SeatingChart/ClassroomFurniture.jsx
+++ b/client/src/components/SeatingChart/ClassroomFurniture.jsx
@@ -28,6 +28,26 @@ const ClassroomFurniture = ({
         const alreadySelected = selectedItems.some(
           (furnitureId) => furnitureId === item._id
         );
+
+        const radians = (furniturePositions[item._id]?.rotation * Math.PI) / 180;
+        const sinTheta = Math.abs(Math.sin(radians));
+        const cosTheta = Math.abs(Math.cos(radians));
+
+        const constraintsFurnWidth = shape.style.width.split("[")[1].split("px]")[0]/2
+        const constraintsFurnHeight = shape.style.height.split("[")[1].split("px]")[0]/2
+
+        let dragConstraints = {};
+        if (furniturePositions[item._id]?.rotation % 360 === 90 || furniturePositions[item._id]?.rotation % 360 === 270) {
+          dragConstraints = {
+            left: -constraintsFurnWidth -(constraintsFurnWidth * cosTheta)+10,
+            right: 710 - constraintsFurnWidth - (constraintsFurnHeight * cosTheta), 
+            top: (constraintsFurnWidth) - (constraintsFurnHeight * sinTheta) - 10,
+            bottom: 710 - (constraintsFurnHeight) - (constraintsFurnWidth * sinTheta),
+          };
+        } else {
+          dragConstraints = constraintsRef;
+        }
+
         return (
           <motion.div
             id={`furniture-${item._id}`}
@@ -45,7 +65,7 @@ const ClassroomFurniture = ({
             drag
             dragElastic={0.1}
             dragPropagation={false}
-            dragConstraints={constraintsRef}
+            dragConstraints={dragConstraints}
             onDragStart={() => setIsDragging(true)}
             onDragEnd={() => {
               handleDragEnd(item._id, "furniture");
@@ -80,7 +100,7 @@ const ClassroomFurniture = ({
             }`}
           >
             <img
-              className="flex w-full h-full"
+              className="flex w-full h-full border-pink"
               src={shape.src}
               alt={shape.alt}
             />

--- a/client/src/components/SeatingChart/ClassroomFurniture.jsx
+++ b/client/src/components/SeatingChart/ClassroomFurniture.jsx
@@ -83,11 +83,6 @@ const ClassroomFurniture = ({
                     0;
                   const newRotation = prevRotation + 90;
 
-                  console.log("furniture position? " + JSON.stringify(furniturePositions))
-                  console.log("New rotation: " + newRotation)
-                  console.log("item.x: " + item.x)
-                  console.log("item.y: " + item.y)
-
                   return {
                     ...prevPositions,
                     [item._id]: {
@@ -105,7 +100,7 @@ const ClassroomFurniture = ({
             }`}
           >
             <img
-              className="flex w-full h-full border-pink"
+              className="flex w-full h-full"
               src={shape.src}
               alt={shape.alt}
             />

--- a/client/src/components/SeatingChart/ClassroomFurniture.jsx
+++ b/client/src/components/SeatingChart/ClassroomFurniture.jsx
@@ -29,7 +29,7 @@ const ClassroomFurniture = ({
           (furnitureId) => furnitureId === item._id
         );
 
-        const radians = (furniturePositions[item._id]?.rotation * Math.PI) / 180;
+        const radians = ((furniturePositions[item._id]?.rotation || item?.rotation) * Math.PI) / 180;
         const sinTheta = Math.abs(Math.sin(radians));
         const cosTheta = Math.abs(Math.cos(radians));
 
@@ -37,7 +37,7 @@ const ClassroomFurniture = ({
         const constraintsFurnHeight = shape.style.height.split("[")[1].split("px]")[0]/2
 
         let dragConstraints = {};
-        if (furniturePositions[item._id]?.rotation % 360 === 90 || furniturePositions[item._id]?.rotation % 360 === 270) {
+        if ((furniturePositions[item._id]?.rotation || item?.rotation) % 360 === 90 || (furniturePositions[item._id]?.rotation || item?.rotation) % 360 === 270) {
           dragConstraints = {
             left: -constraintsFurnWidth -(constraintsFurnWidth * cosTheta)+10,
             right: 710 - constraintsFurnWidth - (constraintsFurnHeight * cosTheta), 
@@ -54,13 +54,13 @@ const ClassroomFurniture = ({
             key={`${item._id}`}
             dragMomentum={false}
             initial={{
-              x: Math.max(0, initialX),
-              y: Math.max(0, initialY),
+              x: initialX,
+              y: initialY,
               rotate: item.rotation || 0,
             }}
             animate={{
               rotate:
-                furniturePositions[item._id]?.rotation || item.rotation || 0,
+                furniturePositions[item._id]?.rotation || item.rotation,
             }}
             drag
             dragElastic={0.1}
@@ -82,6 +82,11 @@ const ClassroomFurniture = ({
                     item.rotation ||
                     0;
                   const newRotation = prevRotation + 90;
+
+                  console.log("furniture position? " + JSON.stringify(furniturePositions))
+                  console.log("New rotation: " + newRotation)
+                  console.log("item.x: " + item.x)
+                  console.log("item.y: " + item.y)
 
                   return {
                     ...prevPositions,

--- a/client/src/pages/teacher/EditSeatingChart.jsx
+++ b/client/src/pages/teacher/EditSeatingChart.jsx
@@ -140,6 +140,7 @@ const EditSeatingChart = () => {
         );
 
         console.log("furnish coords: " + furnishCoords);
+        console.log("furniture rotation: " + furniturePositions[itemId]?.rotation)
 
         if (furnishCoords) {
           setFurniturePositions((prevPositions) => ({
@@ -148,7 +149,7 @@ const EditSeatingChart = () => {
               x: parseInt(furnishCoords[1]),
               y: parseInt(furnishCoords[2]),
               assigned: true,
-              rotation: furniturePositions[itemId]?.rotation,
+              rotation: furniturePositions[itemId]?.rotation || classroom.furniture[itemId]?.rotation,
             },
           }));
         } else {
@@ -187,13 +188,15 @@ const EditSeatingChart = () => {
     const updatedFurniturePositions = Object.keys(furniturePositions).map(
       (itemId) => {
         const furniture = furniturePositions[itemId];
-        console.log("furniture: " + JSON.stringify(furniture));
+        const furnitureItem = classroom.furniture.find(item => item._id === itemId);
+        const furnitureRotation = furnitureItem?.rotation;
+
         return {
           itemId,
           x: furniture.x,
           y: furniture.y,
           assigned: furniture.assigned,
-          rotation: furniture.rotation || 0,
+          rotation: furniture.rotation || furnitureRotation,
         };
       }
     );


### PR DESCRIPTION
Bug issue: When furniture was rotated 90 and 270 degrees, there was a barrier preventing from moving it to either edge. It was moving based on the width and height when rotated 0 or 180 degrees. 

Bug Fixed: In ClassroomFurniture file, I set up a way to calculate the boundaries if it's rotated 90 & 270 degrees, and if it's rotated 0 and 180 degrees. Also, changed initial x and y from Max(0, initialX/Y) to just initialX / initialY. Changed dragElastic to 0 so that it prevent saving the object outside of the classroom.