### PR TITLE
Seating Chart Bug Fix

### DIFF
--- a/client/src/components/SeatingChart/AssignedStudent.jsx
+++ b/client/src/components/SeatingChart/AssignedStudent.jsx
@@ -58,7 +58,7 @@ const AssignedStudent = ({
               className={`absolute border-4 px-[4px] rounded-2xl ${
                 selectedStyling ? "border-black" : ` border-${borderColorClass}`
               } ${borderColorClass === "sandwich" ? "bg-[#ece6d2]" : `bg-${borderColorClass}`}`}
-              onClick={() => {
+              onDoubleClick={() => {
                 setSelectedStudents(toggleSelected(newFormat, alreadySelected, selectedStudents));
               }}
               onDragEnd={(event, info) => {

--- a/client/src/components/SeatingChart/ClassroomFurniture.jsx
+++ b/client/src/components/SeatingChart/ClassroomFurniture.jsx
@@ -73,6 +73,7 @@ const ClassroomFurniture = ({
             }}
             onClick={() => {
               setSelectedItems(toggleSelected(item._id, alreadySelected, selectedItems))
+              handleDragEnd(item._id, "furniture");
             }}
             onDoubleClick={() => {
               if (!isDragging) {


### PR DESCRIPTION
Fixed a bug where moved classroom objects were not being saved in the new spot. Issue was both student and furniture were only recognizing the single click when dragged. Now for students it's a double click to select, and for furniture it recognizes it being moved even when clicked.