### PR TITLE
Mobile Stlying for Classlist Page Edit Mode, quick touch ups

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -10,6 +10,7 @@ body {
   /* Adjust styles according to your design */
   ::-webkit-scrollbar {
     width: 8px;
+    height: 8px;
   }
   
   ::-webkit-scrollbar-thumb {

--- a/client/src/components/ButtonView.jsx
+++ b/client/src/components/ButtonView.jsx
@@ -17,12 +17,12 @@ const ButtonView = ({
     <>
       <div className={`${buttonSize !== "small" ? "mx-2" : ""}`}>
         <button
-          className={`text-[Poppins] rounded-xl flex items-center ${buttonSize === "small" ? "border-[2px] border-sandwich flex-col-reverse h-[80px] md:h-24 w-20 text-[13px] justify-center" : "text-[16px] border-[4px] border-sandwich h-20 w-[270px] justify-around" }   ${
+          className={`text-[Poppins] rounded-xl flex items-center ${buttonSize === "small" ? "border-[2px] border-sandwich flex-row-reverse md:flex-col-reverse h-[50px] md:h-24 w-[150px] md:w-20 text-[13px] justify-center" : "text-[16px] border-[4px] border-sandwich h-20 w-[270px] justify-around" }   ${
             isSelected ? "underline font-[700] bg-sandwich" : "bg-notebookPaper"
           }`}
           onClick={handleClick}
         >
-          <h4 className="pt-2">{buttonText}</h4>
+          <h4 className="pl-2 md:pl-0 md:pt-2">{buttonText}</h4>
           <div className="h-6 flex items-center">
           <img
           className="w-6"

--- a/client/src/components/ButtonView.jsx
+++ b/client/src/components/ButtonView.jsx
@@ -17,7 +17,7 @@ const ButtonView = ({
     <>
       <div className={`${buttonSize !== "small" ? "mx-2" : ""}`}>
         <button
-          className={`text-[Poppins] rounded-xl flex items-center ${buttonSize === "small" ? "border-[2px] border-sandwich flex-row-reverse md:flex-col-reverse h-[50px] md:h-24 w-[150px] md:w-20 text-[13px] justify-center" : "text-[16px] border-[4px] border-sandwich h-20 w-[270px] justify-around" }   ${
+          className={`text-[Poppins] rounded-xl flex items-center ${buttonSize === "small" ? "border-[2px] border-sandwich flex-row-reverse md:flex-col-reverse h-[50px] md:h-24 w-[140px] xs:w-[150px] md:w-20 text-[13px] justify-center" : "text-[16px] border-[4px] border-sandwich h-20 w-[270px] justify-around" }   ${
             isSelected ? "underline font-[700] bg-sandwich" : "bg-notebookPaper"
           }`}
           onClick={handleClick}
@@ -25,7 +25,7 @@ const ButtonView = ({
           <h4 className="pl-2 md:pl-0 md:pt-2">{buttonText}</h4>
           <div className="h-6 flex items-center">
           <img
-          className="w-6"
+          className="w-10 pl-2 xs:w-6"
             src={!isSelected ? defaultBtnImage : btnImageWhenOpen}
             alt={buttonText}
           />

--- a/client/src/components/StudentInfoBox.jsx
+++ b/client/src/components/StudentInfoBox.jsx
@@ -27,13 +27,13 @@ const StudentInfoBox = ({
         {/* student image */}
         <div
           className={`flex ${
-            bgColorClass ? `w-32 sm:w-full bg-${bgColorClass} flex justify-center border-${borderColorClass}` : "w-32 sm:w-28 opacity-50 bg-[#ece6d2] border-sandwich"
+            bgColorClass ? `w-28 md:w-32 sm:w-full bg-${bgColorClass} flex justify-center border-${borderColorClass}` : "w-28 opacity-50 bg-[#ece6d2] border-sandwich"
           }`}
         >
           <img
             src={student.avatarImg === "none" ? avatarImg : student.avatarImg}
             alt={student.firstName}
-            className={`flex w-24 h-24 rounded-2xl p-2 self-center  ${
+            className={`flex w-20 h-20 md:w-24 md:h-24 rounded-2xl p-2 self-center  ${
               borderColorClass ===
               "sandwich"
                 ? "opacity-50"
@@ -46,9 +46,9 @@ const StudentInfoBox = ({
         <div className="flex flex-col sm:flex-row w-full sm:w-[80%] px-2 sm:px-4 my-2 sm:my-5">
           <div>
           {/* last emotion */}
-          <div className="pb-2 flex justify-between">
+          <div className="md:pb-2 flex justify-between">
             {lastCheck ? (
-              <div className="font-[Poppins] text-[15px] sm:text-[17px] px-2">
+              <div className="font-[Poppins] text-[14px] sm:text-[17px] px-2">
                 <h4>
                   {student.firstName} {student.lastName}
                 </h4>

--- a/client/src/pages/teacher/EditSeatingChart.jsx
+++ b/client/src/pages/teacher/EditSeatingChart.jsx
@@ -236,7 +236,7 @@ const EditSeatingChart = () => {
         <div className="flex flex-col w-full h-full items-center max-w-3xl">
           {/* top half of page */}
         <div className="flex flex-col h-[28vh] md:h-auto w-screen md:w-full top-0 sticky md:flex-row max-w-[900px] justify-start mb-2 mt-5 mx-4 md:ml-5 z-20">
-          <div className="w-1/3">
+          <div className="w-2/3">
             <SimpleTopNav
               pageTitle={classroom?.classSubject}
               fontsize="text-[22px] md:text-[30px] xl:text-[24px]"

--- a/client/src/pages/teacher/EditSeatingChart.jsx
+++ b/client/src/pages/teacher/EditSeatingChart.jsx
@@ -235,53 +235,17 @@ const EditSeatingChart = () => {
         {/* page container */}
         <div className="flex flex-col w-full h-full items-center max-w-3xl">
           {/* top half of page */}
-        <div className="flex flex-col h-[50vh] md:h-auto  w-screen md:w-full top-0 sticky md:flex-row max-w-[900px] justify-start mb-2 mt-5 mx-4 md:ml-5 z-20">
+        <div className="flex flex-col h-[28vh] md:h-auto w-screen md:w-full top-0 sticky md:flex-row max-w-[900px] justify-start mb-2 mt-5 mx-4 md:ml-5 z-20">
+          <div className="w-1/3">
             <SimpleTopNav
               pageTitle={classroom?.classSubject}
               fontsize="text-[22px] md:text-[30px] xl:text-[24px]"
             />
-            <div className="flex flex-col mx-8 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
+            </div>
+            <div className="flex flex-col mx-8 md:flex-row justify-center md:items-center">
+              
               <div
-                className="flex items-center w-full justify-between md:hidden"
-                onClick={() => setIsOpen(!isOpen)}
-              >
-                <h2 className="md:hidden my-5 md:my-0 font-semibold text-[15px] font-[Poppins]">
-                  Details
-                </h2>
-                <svg
-                  className={`transition-transform duration-300 md:hidden ${
-                    isOpen ? "" : "rotate-180"
-                  }`}
-                  width="70"
-                  height="70"
-                  viewBox="0 -25 100 100"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="50"
-                    y1="10"
-                    x2="35"
-                    y2="30"
-                    stroke="#8D8772"
-                    strokeWidth="4"
-                    strokeLinecap="round"
-                  />
-
-                  <line
-                    x1="50"
-                    y1="10"
-                    x2="65"
-                    y2="30"
-                    stroke="#8D8772"
-                    strokeWidth="4"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </div>
-              <div
-                className={`transition-all duration-500 ease-in-out md:flex overflow-hidden ${
-                  isOpen ? "max-h-[500px]" : "max-h-0"
-                } md:max-h-full md:h-auto`}
+                className={`hidden md:flex overflow-hidden max-h-[500px] md:max-h-full md:h-auto`}
               >
                 <ClassDetails
                   teacherId={teacherId}

--- a/client/src/pages/teacher/EditSeatingChart.jsx
+++ b/client/src/pages/teacher/EditSeatingChart.jsx
@@ -291,7 +291,7 @@ const EditSeatingChart = () => {
               </div>
             </div>
             {/* Room View & List Buttons */}
-            <div className="flex md:hidden justify-around md:justify-between gap-4 items-center mt-5 bg-notebookPaper">
+            <div className="flex md:hidden justify-around md:justify-between gap-2 md:gap-4 items-center mt-5 bg-notebookPaper">
                 <ButtonView
                   buttonText="Student Roster"
                   defaultBtnImage={RosterImg}

--- a/client/src/pages/teacher/NeedsGoals.jsx
+++ b/client/src/pages/teacher/NeedsGoals.jsx
@@ -192,7 +192,7 @@ const NeedsGoals = () => {
             {goalAnswers.map((answer, index) => (
               <div
                 key={index}
-                className={`flex bg-white rounded-[1rem] border-graphite border-[4px]  items-center justify-between mt-[1rem] mb-[1rem]`}
+                className={`flex ${editGoalMode[index] ? "bg-white" : "bg-sandwich" } rounded-[1rem] border-graphite border-[4px]  items-center justify-between mt-[1rem] mb-[1rem]`}
               >
                 {editGoalMode[index] ? (
                   <textarea
@@ -314,7 +314,7 @@ const NeedsGoals = () => {
             {needAnswers.map((answer, index) => (
               <div
                 key={index}
-                className={`flex bg-white rounded-[1rem] border-graphite border-[4px]  items-center justify-between mt-[1rem] mb-[1rem]`}
+                className={`flex ${editNeedsMode[index] ? "bg-white" : "bg-sandwich" } rounded-[1rem] border-graphite border-[4px]  items-center justify-between mt-[1rem] mb-[1rem]`}
               >
                 {editNeedsMode[index] ? (
                   <textarea

--- a/client/src/pages/teacher/ViewClassList.jsx
+++ b/client/src/pages/teacher/ViewClassList.jsx
@@ -112,9 +112,8 @@ const ViewClassList = () => {
 
   return (
     <>
-
-      <div className="flex flex-col h-screen min-w-screen">
-      {/* <div className="flex justify-center lg:justify-end underline mt-4 px-2 md:px-5">
+      <div className="flex flex-col min-h-screen md:h-screen min-w-screen mb-44 lg:pb-0">
+        {/* <div className="flex justify-center lg:justify-end underline mt-4 px-2 md:px-5">
         <Logout location="teacherLogout" userData={userData} />
       </div> */}
         <div className="flex flex-col h-full items-center w-full lg:z-40 mt-4">
@@ -123,28 +122,30 @@ const ViewClassList = () => {
               {isEditMode ? (
                 <>
                   {/* Top Nav (on Edit only)*/}
-                  <div className="mt-8">
+                  <div className="flex w-full md:w-[45%] justify-start md:mt-8">
                     <SimpleTopNav
                       pageTitle="Manage Classroom"
-                      fontsize="text-[30px]"
+                      fontsize="text-[20px] md:text-[30px]"
                     />
                   </div>
 
                   {/* Classroom Info (on Edit only) */}
-                  <div className="bg-sandwich w-[80%] max-w-[530px] ml-auto mr-auto px-5 rounded-[1rem] my-[1rem] mb-14">
+                  <div className="bg-sandwich w-[80%] max-w-[530px] ml-auto mr-auto px-5 rounded-[1rem] my-[1rem] mb-5 md:mb-14">
                     <input
-                      className="flex w-44 h-10 border-2 border-gray rounded my-3 pl-3 text-[22px]"
+                      className="flex w-full md:w-44 h-10 border-2 border-gray rounded my-3 pl-3 text-[18px] md:text-[22px]"
                       name="classSubject"
                       placeholder="Subject"
                       value={classroom.classSubject}
                       onChange={handleChange}
                     />
                     <div className="bg-notebookPaper p-[0.3rem] rounded-[1rem]">
-                      <div className="flex justify-between mx-2">
+                      <div className="flex flex-col md:flex-row justify-between mx-2">
                         <div className="flex-col text-sm font-body">
-                          <h2>Location:</h2>
+                          <h2 className="text-[14px] md:text-[16px]">
+                            Location:
+                          </h2>
                           <input
-                            className="border-2 w-56 border-gray rounded pl-3 py-1 text-[18px]"
+                            className="border-2 w-44 xs:w-56 border-gray rounded pl-3 py-1 text-[15px] md:text-[18px]"
                             name="location"
                             placeholder="Room 123"
                             value={classroom.location}
@@ -152,34 +153,36 @@ const ViewClassList = () => {
                           />
                         </div>
 
-                        <div className="flex-col text-sm font-body ">
-                          <div className="flex gap-4">
-                            <div>
-                              <h2>Check-in:</h2>
-                              <input
-                                className="flex w-24 border-2 border-gray rounded pl-2 py-1 text-[18px]"
-                                name="checkIn"
-                                type="time"
-                                value={classroom.checkIn}
-                                onChange={handleChange}
-                              />
-                            </div>
-                            <div>
-                              <h2>Check-out:</h2>
-                              <input
-                                className="flex w-24 border-2 border-gray rounded pl-2 py-1 text-[18px]"
-                                name="checkOut"
-                                type="time"
-                                value={classroom.checkOut}
-                                onChange={handleChange}
-                              />
-                            </div>
+                        <div className="flex text-sm font-body gap-4 mt-2">
+                          <div>
+                            <h2 className="text-[14px] md:text-[16px]">
+                              Check-in:
+                            </h2>
+                            <input
+                              className="flex w-20 xs:w-24 border-2 border-gray rounded pl-2 py-1 text-[15px] md:text-[18px]"
+                              name="checkIn"
+                              type="time"
+                              value={classroom.checkIn}
+                              onChange={handleChange}
+                            />
+                          </div>
+                          <div>
+                            <h2 className="text-[14px] md:text-[16px]">
+                              Check-out:
+                            </h2>
+                            <input
+                              className="flex w-20 xs:w-24 border-2 border-gray rounded pl-2 py-1 text-[15px] md:text-[18px]"
+                              name="checkOut"
+                              type="time"
+                              value={classroom.checkOut}
+                              onChange={handleChange}
+                            />
                           </div>
                         </div>
                       </div>
                     </div>
-                    <div className="flex justify-center bg-sandwich rounded-[1rem]  py-[0.8rem]">
-                      <h2 className="text-header3 font-semibold font-[Poppins] underline">
+                    <div className="flex justify-center bg-sandwich rounded-[1rem] py-[0.8rem]">
+                      <h2 className="text-[16px] md:text-header3 font-semibold font-[Poppins] underline">
                         <a
                           href={`/edit-seating-chart/${teacherId}/${classroomId}`}
                         >
@@ -199,9 +202,7 @@ const ViewClassList = () => {
                   </div>
                   <div className="flex flex-col-reverse md:flex-row xl:gap-8">
                     <div className="hidden md:flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
-                      <div
-                        className={`flex overflow-hidden max-h-full`}
-                      >
+                      <div className={`flex overflow-hidden max-h-full`}>
                         <ClassDetails
                           teacherId={teacherId}
                           classroomId={classroomId}
@@ -233,15 +234,33 @@ const ViewClassList = () => {
               )}
 
               <ToggleButton students={students} setStudents={setStudents} />
-              <div>
-                <h2 className="text-header3 font-header2 text-center my-[1rem]">
+              <div className="w-full max-w-[700px]">
+                <h2 className="text-[16px] md:text-header3 font-header2 text-center my-[1rem] ">
                   {isEditMode ? (
-                    <Link
-                      className="underline"
-                      to={`/addstudent/${teacherId}/${classroomId}`}
-                    >
-                      Add new student
-                    </Link>
+                    <div className="flex w-full justify-center items-center">
+                      <Link
+                        className="underline w-[104%]"
+                        to={`/addstudent/${teacherId}/${classroomId}`}
+                      >
+                        Add new student
+                      </Link>
+                      {/* Buttons for Home and save/edit */}
+                      <div className="flex flex-col w-[90%] mt-[1rem]">
+                        <div className="flex justify-center text-body font-body pb-2">
+                          <div>
+                            {/* <button onClick={() => setIsEditMode(!isEditMode)}> */}
+                            <button
+                              className={`${
+                                isEditMode ? "flex" : "hidden"
+                              } px-3 py-2 bg-lightCyan text-[14px] sm:text-[16px] border-lightBlue border-2 rounded-md`}
+                              onClick={saveClassroomInfo}
+                            >
+                              {isEditMode ? "Save Changes" : ""}
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   ) : (
                     ""
                   )}
@@ -250,15 +269,15 @@ const ViewClassList = () => {
 
               {/* Scrollable list of students */}
               <div
-                className={`mb-14 px-4 md:px-0 md:mb-0 flex w-full justify-center sm:overflow-y-auto custom-scrollbar ${
-                  isEditMode ? "h-[35%]" : "h-full sm:h-[55%]"
+                className={`px-4 md:px-0 md:mb-0 flex w-full md:justify-center md:overflow-y-auto md:custom-scrollbar ${
+                  isEditMode ? "h-full md:h-[35%]" : "h-full sm:h-[55%]"
                 } pt-3 `}
                 key="list-of-students-1"
               >
                 {sortedStudents.length > 0 ? (
                   <div
                     key={`container`}
-                    className="mt-6 grid grid-cols-1 xl:grid-cols-2 gap-6 h-32"
+                    className="mt-6 grid grid-cols-1 xl:grid-cols-2 gap-6 md:h-32"
                   >
                     {sortedStudents.map((student, index) => {
                       return (
@@ -285,36 +304,19 @@ const ViewClassList = () => {
           ) : (
             "Loading..."
           )}
-
-          {/* Buttons for Home and save/edit */}
-          <div className="flex flex-col w-[70%] mt-[1rem] pb-6">
-            <div className="flex justify-between text-body font-body pb-2">
-              <a href="/teacher-home">&lt; All Classes</a>
-              <div>
-                {/* <button onClick={() => setIsEditMode(!isEditMode)}> */}
-                <button
-                  className={`${
-                    isEditMode ? "flex" : "hidden"
-                  } px-3 py-2 bg-lightCyan border-lightBlue border-2 rounded-md`}
-                  onClick={saveClassroomInfo}
-                >
-                  {isEditMode ? "Save Changes" : ""}
-                </button>
-              </div>
-            </div>
-          </div>
         </div>
         {/* <div className="fixed bottom-0 w-screen">
         <TeacherNavbar setIsEditMode={setIsEditMode} />
         </div> */}
-        <div className="bottom-0 z-40 fixed w-screen lg:inset-y-0 lg:left-0 lg:order-first lg:w-44 ">
+
+      </div>
+      <div className="bottom-0 z-40 fixed w-screen lg:inset-y-0 lg:left-0 lg:order-first lg:w-44 ">
           <Nav
             setIsEditMode={setIsEditMode}
             teacherId={teacherId}
             classroomId={classroomId}
           />
         </div>
-      </div>
     </>
   );
 }

--- a/client/src/pages/teacher/ViewClassList.jsx
+++ b/client/src/pages/teacher/ViewClassList.jsx
@@ -114,10 +114,10 @@ const ViewClassList = () => {
     <>
 
       <div className="flex flex-col h-screen min-w-screen">
-      <div className="flex justify-center lg:justify-end underline mt-4 px-2 md:px-5">
+      {/* <div className="flex justify-center lg:justify-end underline mt-4 px-2 md:px-5">
         <Logout location="teacherLogout" userData={userData} />
-      </div>
-        <div className="flex flex-col h-full items-center w-full lg:z-40 md:mt-4">
+      </div> */}
+        <div className="flex flex-col h-full items-center w-full lg:z-40 mt-4">
           {classroom ? (
             <>
               {isEditMode ? (
@@ -198,48 +198,9 @@ const ViewClassList = () => {
                     />
                   </div>
                   <div className="flex flex-col-reverse md:flex-row xl:gap-8">
-                    <div className="flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
+                    <div className="hidden md:flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
                       <div
-                        className="flex items-center w-full justify-between md:hidden"
-                        onClick={() => setIsOpen(!isOpen)}
-                      >
-                        <h2 className="md:hidden my-5 md:my-0 font-semibold text-[15px] font-[Poppins]">
-                          Details
-                        </h2>
-                        <svg
-                          className={`transition-transform duration-300 md:hidden ${
-                            isOpen ? "" : "rotate-180"
-                          }`}
-                          width="70"
-                          height="70"
-                          viewBox="0 -25 100 100"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <line
-                            x1="50"
-                            y1="10"
-                            x2="35"
-                            y2="30"
-                            stroke="#8D8772"
-                            strokeWidth="4"
-                            strokeLinecap="round"
-                          />
-
-                          <line
-                            x1="50"
-                            y1="10"
-                            x2="65"
-                            y2="30"
-                            stroke="#8D8772"
-                            strokeWidth="4"
-                            strokeLinecap="round"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        className={`transition-all duration-500 ease-in-out md:flex overflow-hidden ${
-                          isOpen ? "max-h-[500px]" : "max-h-0"
-                        } md:max-h-full md:h-auto`}
+                        className={`flex overflow-hidden max-h-full`}
                       >
                         <ClassDetails
                           teacherId={teacherId}

--- a/client/src/pages/teacher/ViewClassroom.jsx
+++ b/client/src/pages/teacher/ViewClassroom.jsx
@@ -101,7 +101,7 @@ const ViewClassroom = () => {
       <div className="flex flex-col md:flex-row h-screen w-screen md:justify-center">
         <div className="flex flex-col items-center max-w-4xl lg:z-40">
           {/* Top Navbar */}
-          <div className="flex flex-col h-[35vh] md:h-auto w-full md:justify-center md:mt-14 pt-2 px-5 xl:gap-8 z-20">
+          <div className="flex flex-col h-[35vh] md:h-auto w-full md:justify-center md:mt-14 pt-2 px-2 xl:gap-8 z-20">
             <div className="flex flex-col md:flex-row">
             <div className="flex md:justify-center">
               <SimpleTopNav
@@ -121,7 +121,7 @@ const ViewClassroom = () => {
                 </div>
               </div>
               {/* Room View & List Buttons */}
-              <div className="flex justify-around md:justify-between gap-4 items-center mb-5 md:mb-0">
+              <div className="flex justify-around md:justify-between gap-2 items-center mb-5 md:mb-0">
                 <ButtonView
                   buttonText="Room View"
                   btnImageWhenOpen={classBoxesIcon}

--- a/client/src/pages/teacher/ViewClassroom.jsx
+++ b/client/src/pages/teacher/ViewClassroom.jsx
@@ -101,7 +101,8 @@ const ViewClassroom = () => {
       <div className="flex flex-col md:flex-row h-screen w-screen md:justify-center">
         <div className="flex flex-col items-center max-w-4xl lg:z-40">
           {/* Top Navbar */}
-          <div className="flex flex-col h-[27vh] md:h-auto w-full md:justify-center md:flex-row md:mt-14 pt-2 px-5 md:mb-10 xl:gap-8 z-20" >
+          <div className="flex flex-col h-[35vh] md:h-auto w-full md:justify-center md:mt-14 pt-2 px-5 xl:gap-8 z-20">
+            <div className="flex flex-col md:flex-row">
             <div className="flex md:justify-center">
               <SimpleTopNav
                 pageTitle={classroom?.classSubject}
@@ -110,7 +111,6 @@ const ViewClassroom = () => {
             </div>
             <div className="flex flex-col-reverse md:flex-row xl:gap-8 bg-notebookPaper">
               <div className="hidden md:flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
-                
                 <div
                   className={`flex overflow-hidden max-h-[500px] md:max-h-full h-auto`}
                 >
@@ -140,19 +140,31 @@ const ViewClassroom = () => {
                   />
                 </Link>
               </div>
+              </div>
             </div>
-
+            <div className="flex items-center justify-center h-full">
+            <h2 className="text-[14px] md:text-[16px] font-semibold font-[Poppins] underline bg-sandwich rounded-[1rem] mb-[1rem] p-[0.8rem] ">
+              <a href={`/edit-seating-chart/${teacherId}/${classroomId}`}>
+                Edit Seating Chart
+              </a>
+            </h2>
           </div>
-          <div className={`${Object.keys(selectedStudent).length === 0
-                        ? "hidden"
-                        : "fixed w-full h-full"
-                    } bg-graphite md:hidden md:bg-none z-30 md:z-0 top-0 opacity-50 md:opacity-0`}></div>
+          </div>
+
+
+
+          <div
+            className={`${
+              Object.keys(selectedStudent).length === 0
+                ? "hidden"
+                : "fixed w-full h-full"
+            } bg-graphite md:hidden md:bg-none z-30 md:z-0 top-0 opacity-50 md:opacity-0`}
+          ></div>
 
           {classroom ? (
             <>
-            {/* static classroom */}
-              <div className="relative flex w-full md:w-[752px] md:h-[654px] h-[73vh] overflow-scroll md:overflow-visible shadow-inner-md md:shadow-none scrollbar-bg-transparent">
-
+              {/* static classroom */}
+              <div className="relative flex w-full md:w-[752px] md:h-[654px] h-[65vh] overflow-scroll md:overflow-visible shadow-inner-md md:shadow-none scrollbar-bg-transparent">
                 {/* Classroom Container */}
                 {/* movable classroom */}
                 <div
@@ -164,7 +176,7 @@ const ViewClassroom = () => {
                   } relative flex w-[752px] h-[654px] rounded-[1rem] mt-10 ml-10 md:mt-0 md:ml-0 md:border-[#D2C2A4] md:border-[8px] md:rounded-[1rem] `}
                   ref={constraintsRef}
                   style={{
-                    transform: `scale(${zoom})`
+                    transform: `scale(${zoom})`,
                   }}
                 >
                   {/* to make the classroom width 752 on smaller screens. Not sure why it just doesn't work on the div itself */}
@@ -277,7 +289,9 @@ const ViewClassroom = () => {
           {/* Student Info Modal */}
           <div
             className={`${
-              Object.keys(selectedStudent).length === 0 ? "hidden" : "fixed top-[35%] sm:top-[40%] md:absolute"
+              Object.keys(selectedStudent).length === 0
+                ? "hidden"
+                : "fixed top-[35%] sm:top-[40%] md:absolute"
             } flex flex-col w-[80%] sm:w-[500px] z-30`}
           >
             <StudentInfoBox
@@ -296,19 +310,19 @@ const ViewClassroom = () => {
           </h4>
         </div>
         <div className="fixed bottom-4 left-2 flex flex-col gap-2 md:hidden justify-center my-4 z-20">
-            <button
-              onClick={handleZoomIn}
-              className=" px-4 py-2 bg-blue text-white rounded"
-            >
+          <button
+            onClick={handleZoomIn}
+            className=" px-4 py-2 bg-blue text-white rounded"
+          >
             +
-            </button>
-            <button
-              onClick={handleZoomOut}
-              className="px-4 py-2 bg-blue text-white rounded"
-            >
-             -
-            </button>
-          </div>
+          </button>
+          <button
+            onClick={handleZoomOut}
+            className="px-4 py-2 bg-blue text-white rounded"
+          >
+            -
+          </button>
+        </div>
         {/* <div className="bottom-0 fixed w-screen">
         <TeacherNavbar  teacherId={teacherId} classroomId={classroomId} />
         </div> */}

--- a/client/src/pages/teacher/ViewClassroom.jsx
+++ b/client/src/pages/teacher/ViewClassroom.jsx
@@ -101,27 +101,29 @@ const ViewClassroom = () => {
       <div className="flex flex-col md:flex-row h-screen w-screen md:justify-center">
         <div className="flex flex-col items-center max-w-4xl lg:z-40">
           {/* Top Navbar */}
-          <div className="flex flex-col h-[35vh] md:h-auto w-full md:justify-center md:mt-14 pt-2 px-2 xl:gap-8 z-20">
-            <div className="flex flex-col md:flex-row">
-            <div className="flex md:justify-center">
-              <SimpleTopNav
-                pageTitle={classroom?.classSubject}
-                fontsize="text-[22px] md:text-[18px] xl:text-[24px]"
-              />
-            </div>
-            <div className="flex flex-col-reverse md:flex-row xl:gap-8 bg-notebookPaper">
-              <div className="hidden md:flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
-                <div
-                  className={`flex overflow-hidden max-h-[500px] md:max-h-full h-auto`}
-                >
-                  <ClassDetails
-                    teacherId={teacherId}
-                    classroomId={classroomId}
+          <div className="flex flex-col h-[35vh] md:h-auto w-full md:justify-between md:mt-14 pt-2 px-2 xl:gap-8 z-20">
+            <div className="flex justify-center w-full flex-col md:flex-row">
+              <div className="flex">
+                <div className="flex md:justify-center">
+                  <SimpleTopNav
+                    pageTitle={classroom?.classSubject}
+                    fontsize="text-[22px] md:text-[18px] xl:text-[24px]"
                   />
+                </div>
+                
+                  <div className="hidden md:flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
+                    <div
+                      className={`flex overflow-hidden max-h-[500px] md:max-h-full h-auto`}
+                    >
+                      <ClassDetails
+                        teacherId={teacherId}
+                        classroomId={classroomId}
+                      />
+                    </div>
                 </div>
               </div>
               {/* Room View & List Buttons */}
-              <div className="flex justify-around md:justify-between gap-2 items-center mb-5 md:mb-0">
+              <div className="flex justify-around md:justify-between gap-4 items-center mb-5 md:mb-0">
                 <ButtonView
                   buttonText="Room View"
                   btnImageWhenOpen={classBoxesIcon}
@@ -139,7 +141,6 @@ const ViewClassroom = () => {
                     buttonSize="small"
                   />
                 </Link>
-              </div>
               </div>
             </div>
             <div className="flex items-center justify-center h-full">

--- a/client/src/pages/teacher/ViewClassroom.jsx
+++ b/client/src/pages/teacher/ViewClassroom.jsx
@@ -101,7 +101,7 @@ const ViewClassroom = () => {
       <div className="flex flex-col md:flex-row h-screen w-screen md:justify-center">
         <div className="flex flex-col items-center max-w-4xl lg:z-40">
           {/* Top Navbar */}
-          <div className="flex flex-col h-[45vh] md:h-auto w-full md:justify-center md:flex-row md:mt-14 pt-2 px-5 md:mb-10 xl:gap-8 z-20" >
+          <div className="flex flex-col h-[27vh] md:h-auto w-full md:justify-center md:flex-row md:mt-14 pt-2 px-5 md:mb-10 xl:gap-8 z-20" >
             <div className="flex md:justify-center">
               <SimpleTopNav
                 pageTitle={classroom?.classSubject}
@@ -109,48 +109,10 @@ const ViewClassroom = () => {
               />
             </div>
             <div className="flex flex-col-reverse md:flex-row xl:gap-8 bg-notebookPaper">
-              <div className="flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
+              <div className="hidden md:flex flex-col px-4 md:flex-row justify-center md:items-center border-t-2 border-b-2 border-sandwich md:border-none">
+                
                 <div
-                  className="flex items-center w-full justify-between md:hidden"
-                  onClick={() => setIsOpen(!isOpen)}
-                >
-                  <h2 className="md:hidden my-5 md:my-0 font-semibold text-[15px] font-[Poppins]">
-                    Details
-                  </h2>
-                  <svg
-                    className={`transition-transform duration-300 md:hidden ${
-                      isOpen ? "" : "rotate-180"
-                    }`}
-                    width="70"
-                    height="70"
-                    viewBox="0 -25 100 100"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <line
-                      x1="50"
-                      y1="10"
-                      x2="35"
-                      y2="30"
-                      stroke="#8D8772"
-                      strokeWidth="4"
-                      strokeLinecap="round"
-                    />
-
-                    <line
-                      x1="50"
-                      y1="10"
-                      x2="65"
-                      y2="30"
-                      stroke="#8D8772"
-                      strokeWidth="4"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className={`transition-all duration-500 ease-in-out md:flex overflow-hidden ${
-                    isOpen ? "max-h-[500px]" : "max-h-0"
-                  } md:max-h-full md:h-auto`}
+                  className={`flex overflow-hidden max-h-[500px] md:max-h-full h-auto`}
                 >
                   <ClassDetails
                     teacherId={teacherId}
@@ -189,7 +151,7 @@ const ViewClassroom = () => {
           {classroom ? (
             <>
             {/* static classroom */}
-              <div className="relative flex w-full md:w-[752px] md:h-[654px] h-[55vh] overflow-scroll md:overflow-visible shadow-inner-md md:shadow-none scrollbar-bg-transparent">
+              <div className="relative flex w-full md:w-[752px] md:h-[654px] h-[73vh] overflow-scroll md:overflow-visible shadow-inner-md md:shadow-none scrollbar-bg-transparent">
 
                 {/* Classroom Container */}
                 {/* movable classroom */}

--- a/client/src/pages/teacher/studentProfile/StudentProfile.jsx
+++ b/client/src/pages/teacher/studentProfile/StudentProfile.jsx
@@ -494,8 +494,8 @@ const StudentProfile = () => {
               <div
                 className={`absolute bg-sandwich rounded-2xl bg-opacity-70 ${
                   isMonthView
-                    ? "top-96 md:top-72 mt-20 md:mt-2 h-96 w-[300px] xs:w-[350px] sm:w-[420px] md:w-[530px]"
-                    : "top-96 md:top-72 mt-20 md:mt-2 h-[245px] w-[300px] xs:w-[350px] sm:w-[420px] md:w-[530px]"
+                    ? "top-96 md:top-72 mt-20 md:mt-12 h-96 w-[300px] xs:w-[350px] sm:w-[420px] md:w-[530px]"
+                    : "top-96 md:top-72 mt-20 md:mt-12 h-[246px] w-[300px] xs:w-[350px] sm:w-[420px] md:w-[530px]"
                 }`}
               >
                 <div className={`flex h-full justify-center items-center`}>


### PR DESCRIPTION
This has updated mobile styling for the class list page's edit mode, and quick touch ups as talked about at the last meeting.
- No container for student list on class list page on mobile screens. Some phone screens were too small to show the student list container, so this is the best, easy to use option for mobile.
- save button for classlist page edit mode is in between the class details section and student list section. Probably will find a new place for it later, so just a temporary placement

for the quick touchups:
- details tab for mobile doesn't show now on the seating chart pages, and classlist page. (but can put it back easily if needed on classlist page)
- scrollbars sizing match
- inputs on goals and needs page now have sandwich color if not edit mode, white bg if it is edit mode.
- updated buttonview components to have icons on left side, text on right for mobile.
- student profile calendar overlay has been fixed