### PR TITLE
FIX: Student container in class list fits on screen in desktop view, student div container reformatted

### DIFF
--- a/client/src/components/StudentInfoBox.jsx
+++ b/client/src/components/StudentInfoBox.jsx
@@ -27,7 +27,7 @@ const StudentInfoBox = ({
         {/* student image */}
         <div
           className={`flex ${
-            bgColorClass ? `w-28 md:w-32 sm:w-full bg-${bgColorClass} flex justify-center border-${borderColorClass}` : "w-28 opacity-50 bg-[#ece6d2] border-sandwich"
+            bgColorClass ? `w-28 md:w-32 bg-${bgColorClass} flex justify-center border-${borderColorClass}` : "w-28 opacity-50 bg-[#ece6d2] border-sandwich"
           }`}
         >
           <img
@@ -43,7 +43,7 @@ const StudentInfoBox = ({
         </div>
 
         {/* text container */}
-        <div className="flex flex-col sm:flex-row w-full sm:w-[80%] px-2 sm:px-4 my-2 sm:my-5">
+        <div className="flex flex-col justify-between sm:flex-row w-full sm:w-[80%] px-2 sm:px-4 my-2 sm:my-5">
           <div>
           {/* last emotion */}
           <div className="md:pb-2 flex justify-between">

--- a/client/src/pages/teacher/AddStudentToClassroom.jsx
+++ b/client/src/pages/teacher/AddStudentToClassroom.jsx
@@ -5,6 +5,13 @@ import TeacherNavbar from '../../components/Navbar/TeacherNavbar';
 import Nav from '../../components/Navbar/Nav';
 import withAuth from '../../hoc/withAuth';
 
+
+// TODO:
+// // logout button only for desktop
+// // add inputs for basic student info and way to upload photo (check out code on student profile page)
+// // add way to add IEP
+// // make certain fields required
+
 const AddStudent = () => {
     const { teacherId, classroomId } = useParams();
     const [studentId, setStudentId] = useState('');

--- a/client/src/pages/teacher/ViewClassList.jsx
+++ b/client/src/pages/teacher/ViewClassList.jsx
@@ -121,12 +121,12 @@ const ViewClassList = () => {
 
   return (
     <>
-      <div className="flex flex-col min-h-screen md:h-screen min-w-screen mb-44 md:mb-0 lg:pb-0">
+      <div className="flex flex-col min-h-screen min-w-screen mb-44 lg:mb-0 lg:pb-0">
         <div className="hidden md:flex justify-center lg:justify-end underline mt-4 px-2 md:px-5">
           <Logout location="teacherLogout" userData={userData} />
         </div>
         <div className="flex flex-col items-center">
-          <div className="flex flex-col h-full items-center w-full max-w-4xl lg:z-40 mt-2">
+          <div className="flex flex-col h-full items-center w-full max-w-5xl lg:z-40 mt-2">
             {classroom ? (
               <>
                 {isEditMode ? (
@@ -305,7 +305,7 @@ const ViewClassList = () => {
                 {/* Scrollable list of students */}
                 <div
                   className={`px-4 md:px-0 md:mb-0 flex w-full justify-center md:overflow-y-auto md:custom-scrollbar ${
-                    isEditMode ? "h-full md:h-[35%]" : "h-full sm:h-[55%]"
+                    isEditMode ? "h-full md:h-[35vh]" : "h-full md:h-[50vh] lg:h-[55vh]"
                   } pt-3 `}
                   key="list-of-students-1"
                 >


### PR DESCRIPTION
Fixes include:
- container now uses vh instead of %. This made it stay on the screen and not cause an unnecessary scroll
- student div on smaller screens had 50% image 50% text. Now, it has been fixed to 20% image, 80% text. 