### PR TITLE
Seating Chart cleanup

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,7 @@ import CreateClass from "./pages/teacher/CreateClass";
 import AddStudentToClassroom from "./pages/teacher/AddStudentToClassroom";
 import ViewClassroom from "./pages/teacher/ViewClassroom";
 import { UnsavedChangesProvider } from "./context/UnsavedChangesContext";
+import Custom404 from "./pages/Custom404"
 
 export default function App() {
   return (
@@ -49,6 +50,7 @@ export default function App() {
             <Route path="/regzone" element={<RegZone />} />
             <Route path="/goalsneeds" element={<GoalsNeeds />} />
             <Route path="/summary" element={<Summary />} />
+            <Route path="*" element={<Custom404 />} />
           </Routes>
           </UnsavedChangesProvider>
         </UserProvider>

--- a/client/src/components/SeatingChart/MsgModal.jsx
+++ b/client/src/components/SeatingChart/MsgModal.jsx
@@ -27,21 +27,25 @@ const MsgModal = ({ msgText, showMsg }) => {
       <AnimatePresence>
         {showMsg && (
           <motion.div
-            className={`fixed bottom-0 z-50 w-full max-w-[1024px] lg:max-w-[780px] object-cover rounded-t-[1rem]`}
+            className={`fixed bottom-0 z-50 w-full max-w-[1024px] lg:max-w-[780px] object-cover rounded-t-[1rem] h-44 sm:h-36`}
             initial={{ y: 100, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: 100, opacity: 0 }}
             transition={{ type: "tween", stiffness: 120, damping: 15 }}
           >
-            <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center mt-2">
+            <div className="absolute top-0 left-0 w-full h-full flex justify-center pt-10 sm:mt-2">
               <h3
                 className={`text-black relative text-center font-[Poppins] font-semibold text-[1.65rem]`}
               >
                 {msgText}
               </h3>
-            </div>
-            <img alt="save success" src={saveBg} className={`w-full h-36`} />
-            <div className="absolute bottom-0 left-12 flex items-end h-full">
+            
+            <div className="flex sm:hidden absolute bottom-0 left-0 w-full items-center justify-center">
+                <img src={successFrog} className="mt-4 sm:mt-2" alt="Success Frog" />
+              </div>
+              </div>
+            <img alt="save success" src={saveBg} className={`w-full h-full sm:h-[200px]`} />
+            <div className="sm:absolute hidden bottom-0 left-12 sm:flex items-end h-full">
               <img src={successFrog} />
             </div>
           </motion.div>

--- a/client/src/components/TeacherView/ConfirmationModal.jsx
+++ b/client/src/components/TeacherView/ConfirmationModal.jsx
@@ -56,7 +56,7 @@ const ConfirmationModal = ({ showDeleteModal, setShowDeleteModal, itemFullName, 
             className="bg-red-500 text-white font-semibold mt-4 p-2 rounded-md"
             onClick={() => removeItemFromSystem()}
             >
-            Delete Student
+            Delete
             </button>
           </div>
         </div>

--- a/client/src/pages/Custom404.jsx
+++ b/client/src/pages/Custom404.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import QuestionFrog from "../images/student/characters/Question_Frog.png"
+import Button from '../components/Button';
+
+function Custom404() {
+  return (
+    <div className="text-center pt-10 sm:pt-40 flex flex-col md:flex-row items-center justify-center ">
+      <img className="w-52 sm:w-auto" src={QuestionFrog} alt="question frog" />
+      <div className="flex flex-col justify-center mt-10 md:mt-0 md:items-center gap-5 font-[Poppins]">
+        <h1 className="text-2xl sm:text-4xl font-bold">404 - Page Not Found</h1>
+        <p className="text-md px-5 sm:px-0 sm:text-lg mt-5 mb-5">
+          The page you are looking for does not exist.
+        </p>
+        <Link to="/" className="flex justify-center">
+          <Button buttonText="Home" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default Custom404;

--- a/client/src/pages/teacher/EditSeatingChart.jsx
+++ b/client/src/pages/teacher/EditSeatingChart.jsx
@@ -50,7 +50,10 @@ const EditSeatingChart = () => {
   const [showMsg, setShowMsg] = useState(false);
   const [emptyMsg, setEmptyMsg] = useState(false);
   const {setHasUnsavedChanges} = useUnsavedChanges();
+  const [scale, setScale] = useState(1);
 
+  const handleZoomIn = () => setScale(prevScale => Math.min(prevScale + 0.1, 1.5));
+  const handleZoomOut = () => setScale(prevScale => Math.max(prevScale - 0.1, 0.5));
 
   const handleRemoveObject = async () => {
     if (selectedStudents.length > 0) {
@@ -240,7 +243,6 @@ const EditSeatingChart = () => {
           <Logout location="teacherLogout" userData={userData} />
         </div>
 
-        {/* FIXME: might neeed to fix page container (this should be full screen) */}
         {/* page container */}
         <div className="flex flex-col w-full h-screen items-center max-w-3xl">
           {/* top half of page */}
@@ -298,7 +300,18 @@ const EditSeatingChart = () => {
                 <div
                   className="relative w-[752px] h-[570px] rounded-[1rem] mt-10 ml-10 md:mt-0 md:ml-0 md:border-[#D2C2A4] md:border-[8px] md:rounded-[1rem] "
                   ref={constraintsRef}
-                >
+                  >
+
+                    {/* Scale wrapper */}
+                  <div
+                    className="absolute top-0 left-0"
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      transform: `scale(${scale})`, // Apply the scale here
+                      transformOrigin: "top left",  // Scale from the top-left corner
+                    }}
+                  >
                   {/* Classroom layout here */}
 
                   <ClassroomFurniture
@@ -321,6 +334,7 @@ const EditSeatingChart = () => {
                     handleDragEnd={handleDragEnd}
                     handleRemoveObject={handleRemoveObject}
                   />
+                </div>
                 </div>
               </div>
             </>
@@ -420,13 +434,13 @@ const EditSeatingChart = () => {
       </div>
       <div className="fixed bottom-28 left-2 flex flex-col md:hidden justify-center gap-2 my-4 z-20">
         <button
-          onClick={() => console.log("coming soon")}
+          onClick={() => handleZoomIn()}
           className="px-4 py-2 bg-blue text-white rounded"
         >
           +
         </button>
         <button
-          onClick={() => console.log("coming soon")}
+          onClick={() => handleZoomOut()}
           className="px-4 py-2 bg-blue text-white rounded"
         >
           -

--- a/client/src/pages/teacher/EditSeatingChart.jsx
+++ b/client/src/pages/teacher/EditSeatingChart.jsx
@@ -308,8 +308,8 @@ const EditSeatingChart = () => {
                     style={{
                       width: "100%",
                       height: "100%",
-                      transform: `scale(${scale})`, // Apply the scale here
-                      transformOrigin: "top left",  // Scale from the top-left corner
+                      transform: `scale(${scale})`,
+                      transformOrigin: "top left",
                     }}
                   >
                   {/* Classroom layout here */}
@@ -422,13 +422,13 @@ const EditSeatingChart = () => {
           </div>
         </div>
         {/* Tells user they have saved the layout */}
-        <div className="flex justify-center">
+
           <MsgModal
             msgText="Save Successful!"
             showMsg={showMsg}
             textColor="text-black"
           />
-        </div>
+
         <UnsavedChanges />
 
       </div>

--- a/client/src/pages/teacher/EditTeacher.jsx
+++ b/client/src/pages/teacher/EditTeacher.jsx
@@ -121,13 +121,12 @@ const EditTeacher = () => {
     return <div>Loading...</div>; // Or redirect to another page, or show an error message
   }
 
-  // FIXME: doesnt work because file is too large to save to a db, need to find another way
-  // const handleFileUpload = (file) => {
-  //   setFormData({
-  //     ...formData,
-  //     avatarImg: file.base64,
-  //   });
-  // };
+  const handleFileUpload = (file) => {
+    setFormData({
+      ...formData,
+      avatarImg: file.base64,
+    });
+  };
   
   return (
     <>
@@ -300,7 +299,7 @@ const EditTeacher = () => {
                     <FileBase
                       type="file"
                       multiple={false}
-                      onDone={() => console.log("nice!")}
+                      onDone={({ base64 }) => handleFileUpload({ base64 })}
                     />
                   </div>
                 </div>

--- a/client/src/pages/teacher/studentProfile/StudentProfile.jsx
+++ b/client/src/pages/teacher/studentProfile/StudentProfile.jsx
@@ -272,13 +272,12 @@ const StudentProfile = () => {
     }
   };
 
-  // FIXME: this should save to a db
-  // const handleFileUpload = (file) => {
-  //   setStudentProfile({
-  //     ...studentProfile,
-  //     avatarImg: file.base64,
-  //   });
-  // };
+  const handleFileUpload = (file) => {
+    setStudentProfile({
+      ...studentProfile,
+      avatarImg: file.base64,
+    });
+  };
 
   return (
     <>
@@ -387,7 +386,7 @@ const StudentProfile = () => {
                           <FileBase
                             type="file"
                             multiple={false}
-                            onDone={() => console.log("nice image!")}
+                            onDone={({ base64 }) => handleFileUpload({ base64 })}
                           />
                         </div>
                       ) : null}
@@ -586,20 +585,6 @@ const StudentProfile = () => {
                   </div>
                 </div>
               )}
-              {/* Selected Day Student Info Modal Overlay*/}
-              {/* {openStudentInfoModal && (
-                <div
-                  className={`absolute bg-sandwich rounded-2xl bg-opacity-70 top-96 md:top-80 mt-[150px] sm:mt-[130px] md:mt-[120px] my-2 h-[368px] w-[300px] xs:w-[350px] sm:w-[420px] md:w-[530px]`}
-                >
-                  <div className={`flex h-full justify-center items-center`}>
-                    <StudentProfileBoxInfo
-                      student={studentProfile}
-                      selectedEntry={lastSelectedCheck}
-                      setOpenStudentInfoModal={setOpenStudentInfoModal}
-                    />
-                  </div>
-                </div>
-              )} */}
             </div>
             <div className="mb-20 mt-6 max-w-2xl">
               <div className="flex flex-col gap-4 md:gap-0 mt-6 mb-2 items-center w-full justify-between ">

--- a/client/src/pages/teacher/studentProfile/StudentProfile.jsx
+++ b/client/src/pages/teacher/studentProfile/StudentProfile.jsx
@@ -139,8 +139,8 @@ const StudentProfile = () => {
       setHasUnsavedChanges(false);
       setEditMode(false);
     } catch (error) {
-      setError("An error occurred while saving the student profile.");
-      console.error(error);
+          setError("An error occurred while saving the student profile.");
+          console.error(error);
     }
 
     try {
@@ -525,7 +525,7 @@ const StudentProfile = () => {
                       {/* Selected Day Student Info Modal Overlay */}
                       {openStudentInfoModal && (
                         <div
-                          className={`absolute bg-sandwich rounded-2xl bg-opacity-70 top-0 h-[368px] w-[300px] xs:w-[350px] sm:w-[420px] md:w-[530px] z-5`} // z-index higher than calendar
+                          className={`absolute bg-sandwich rounded-2xl bg-opacity-70 top-0 h-[120%] w-[300px] xs:w-[350px] sm:w-[420px] md:w-[530px] z-5`} // z-index higher than calendar
                           style={{ left: "50%", transform: "translateX(-50%)" }} // Center modal horizontally
                         >
                           <div


### PR DESCRIPTION
This has the added edit classroom feature for zoom in and zoom out. It also includes:

- fix for how save msg pop up shows on small screens
- custom 404 page, might update with more styling later
- added image saving back to both student and teacher pages
- height for month view overlay fix


Note:
- zoom in feature on mobile make it harder for user to move the classroom items, but this is the only way currently to be able to zoom in and out without changing the classroom size drastically