### PR TITLE
Add Confirmation Modal and Loading screen

### DIFF
--- a/client/src/components/TeacherView/ConfirmationModal.jsx
+++ b/client/src/components/TeacherView/ConfirmationModal.jsx
@@ -10,11 +10,15 @@ const ConfirmationModal = forwardRef(
       inputValue,
       setInputValue,
       removeItemFromSystem,
+      inputNeeded,
+      itemId,
     },
     confirmRef
   ) => {
     const resetInput = () => {
-      setInputValue("");
+      if (inputNeeded) {
+        setInputValue("");
+      }
       closeConfirmModal();
     };
 
@@ -46,22 +50,27 @@ const ConfirmationModal = forwardRef(
             </button>
 
             <h1 className="select-none pt-6">{deleteMsg}</h1>
-            <h2 className="select-none">Type the below text to confirm.</h2>
-            <p id="user-fullname" className="py-5 font-bold">
-              {itemFullName}
-            </p>
-            <input
-              id="name-input"
-              type="text"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              className="border border-gray-300 rounded-md p-2 mt-2 w-full"
-            />
+
+            {inputNeeded ? (
+              <>
+                <h2 className="select-none">Type the below text to confirm.</h2>
+                <p id="user-fullname" className="py-5 font-bold">
+                  {itemFullName}
+                </p>
+                <input
+                  id="name-input"
+                  type="text"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  className="border border-gray-300 rounded-md p-2 mt-2 w-full"
+                />
+              </>
+            ) : null}
             <div className="w-full flex justify-end pt-8">
               <button
                 type="button"
                 className="bg-red-500 text-white font-semibold mt-4 p-2 rounded-md"
-                onClick={() => removeItemFromSystem()}
+                onClick={() => removeItemFromSystem(itemId)}
               >
                 Delete
               </button>

--- a/client/src/components/TeacherView/ConfirmationModal.jsx
+++ b/client/src/components/TeacherView/ConfirmationModal.jsx
@@ -70,7 +70,7 @@ const ConfirmationModal = forwardRef(
               <button
                 type="button"
                 className="bg-red-500 text-white font-semibold mt-4 p-2 rounded-md"
-                onClick={() => removeItemFromSystem(itemId)}
+                onClick={() => removeItemFromSystem(itemId, itemFullName)}
               >
                 Delete
               </button>

--- a/client/src/pages/Authentication/Login.jsx
+++ b/client/src/pages/Authentication/Login.jsx
@@ -37,11 +37,10 @@ const Login = () => {
 
     try {
       const { data } = await axios.post(
-        process.env.REACT_APP_URL +"/login",
+        process.env.REACT_APP_URL + "/login",
         { ...inputValue },
         { withCredentials: true }
       );
-
 
       const { success, message, redirectPath } = data;
 
@@ -49,9 +48,9 @@ const Login = () => {
         handleSuccess(message);
 
         if (redirectPath) {
-          navigate(redirectPath);
+          navigate(`${redirectPath}?login=true`);
         }
-        handleLogin(data.user); 
+        handleLogin(data.user);
       } else {
         handleError(message);
       }
@@ -99,8 +98,8 @@ const Login = () => {
               />
             </div>
 
-            <div className="mt-[2rem] w-[35rem]"> 
-              <BtnRainbow textColor="text-white" btnText="Login"/>
+            <div className="mt-[2rem] w-[35rem]">
+              <BtnRainbow textColor="text-white" btnText="Login" />
             </div>
 
             {/* <button
@@ -132,23 +131,26 @@ const Login = () => {
         {/* Temporary fix for public to view a demo of both student and teacher views  */}
         {/* Normally, admin or teacher would register, because we want it to be secure */}
         <div className="h-2/5 w-full flex justify-center items-center flex-col mt-10 border-4 border-lightGray rounded shadow-2xl bg-sandwich">
-          <button className=" bg-lightOrange w-9/12 py-5 my-5 font-[Poppins] text-[25px] rounded shadow-lg"
-          onClick={ () => {
-            setInputValue({
-              email: process.env.REACT_APP_DEMO_STUDENT_EMAIL,
-              password: process.env.REACT_APP_DEMO_STUDENT_PW,
-            })
-          }}
+          <button
+            className=" bg-lightOrange w-9/12 py-5 my-5 font-[Poppins] text-[25px] rounded shadow-lg"
+            onClick={() => {
+              setInputValue({
+                email: process.env.REACT_APP_DEMO_STUDENT_EMAIL,
+                password: process.env.REACT_APP_DEMO_STUDENT_PW,
+              });
+            }}
           >
             <h4>See demo for Student View</h4>
           </button>
-          <button className=" bg-darkTeal w-9/12 py-5 my-5 font-[Poppins] text-[25px] text-white rounded shadow-lg"
-          onClick={ () => {
-            setInputValue({
-              email: process.env.REACT_APP_DEMO_TEACHER_EMAIL,
-              password: process.env.REACT_APP_DEMO_TEACHER_PW,
-            })
-          }}>
+          <button
+            className=" bg-darkTeal w-9/12 py-5 my-5 font-[Poppins] text-[25px] text-white rounded shadow-lg"
+            onClick={() => {
+              setInputValue({
+                email: process.env.REACT_APP_DEMO_TEACHER_EMAIL,
+                password: process.env.REACT_APP_DEMO_TEACHER_PW,
+              });
+            }}
+          >
             <h4>See demo for Teacher View</h4>
           </button>
         </div>

--- a/client/src/pages/teacher/EditTeacher.jsx
+++ b/client/src/pages/teacher/EditTeacher.jsx
@@ -469,6 +469,7 @@ const EditTeacher = () => {
             inputValue={inputValue}
             setInputValue={setInputValue}
             removeItemFromSystem={deleteTeacherInSystem}
+            inputNeeded={true}
           />
           <PasswordChange
             ref={pwChangeRef}

--- a/client/src/pages/teacher/TeacherHome.jsx
+++ b/client/src/pages/teacher/TeacherHome.jsx
@@ -24,14 +24,21 @@ const TeacherHome = () => {
   const [classroomsData, setClassroomsData] = useState([]);
   const [isEditMode, setIsEditMode] = useState(false);
   const [selectedClassroom, setSelectedClassroom] = useState(null);
-  const confirmRef = useRef(null);
+  const modalRefs = useRef({});
 
-  const openConfirmModal = () => {
-    confirmRef.current?.showModal();
+  const openConfirmModal = (classroomId) => {
+    modalRefs.current[classroomId]?.current?.showModal();
   };
 
-  const closeConfirmModal = () => {
-    confirmRef.current?.close();
+  const closeConfirmModal = (classroomId) => {
+    modalRefs.current[classroomId]?.current?.close();
+  };
+
+  const getModalRef = (classroomId) => {
+    if (!modalRefs.current[classroomId]) {
+      modalRefs.current[classroomId] = React.createRef();
+    }
+    return modalRefs.current[classroomId];
   };
 
   useEffect(() => {
@@ -62,6 +69,7 @@ const TeacherHome = () => {
       setClassroomsData((prevData) =>
         prevData.filter((item) => item.classroom._id !== classroomId)
       );
+      closeConfirmModal(classroomId);
     } catch (error) {
       console.error(error);
     }
@@ -93,7 +101,7 @@ const TeacherHome = () => {
                     {isEditMode ? (
                       <button
                         className="-mt-[3rem] -mx-[2rem]"
-                        onClick={openConfirmModal}
+                        onClick={() => openConfirmModal(classroom._id)}
                       >
                         <img src={xButton} alt="xButton" />
                       </button>
@@ -152,8 +160,8 @@ const TeacherHome = () => {
                   </div>
 
                   <ConfirmationModal
-                    ref={confirmRef}
-                    closeConfirmModal={closeConfirmModal}
+                    ref={getModalRef(classroom._id)}
+                    closeConfirmModal={() => closeConfirmModal(classroom._id)}
                     itemFullName={classroom.classSubject}
                     itemId={classroom._id}
                     deleteMsg={

--- a/client/src/pages/teacher/TeacherHome.jsx
+++ b/client/src/pages/teacher/TeacherHome.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "../../context/UserContext.js";
 import {
@@ -17,12 +17,22 @@ import "./scrollbar.css";
 import TeacherNavbar from "../../components/Navbar/TeacherNavbar.jsx";
 import Nav from "../../components/Navbar/Nav.jsx";
 import withAuth from "../../hoc/withAuth.js";
+import ConfirmationModal from "../../components/TeacherView/ConfirmationModal.jsx";
 
 const TeacherHome = () => {
   const { userData } = useUser();
   const [classroomsData, setClassroomsData] = useState([]);
   const [isEditMode, setIsEditMode] = useState(false);
   const [selectedClassroom, setSelectedClassroom] = useState(null);
+  const confirmRef = useRef(null);
+
+  const openConfirmModal = () => {
+    confirmRef.current?.showModal();
+  };
+
+  const closeConfirmModal = () => {
+    confirmRef.current?.close();
+  };
 
   useEffect(() => {
     const fetchTeacherData = async () => {
@@ -83,7 +93,7 @@ const TeacherHome = () => {
                     {isEditMode ? (
                       <button
                         className="-mt-[3rem] -mx-[2rem]"
-                        onClick={() => handleDeleteClassroom(classroom._id)}
+                        onClick={openConfirmModal}
                       >
                         <img src={xButton} alt="xButton" />
                       </button>
@@ -140,6 +150,18 @@ const TeacherHome = () => {
                       </div>
                     </div>
                   </div>
+
+                  <ConfirmationModal
+                    ref={confirmRef}
+                    closeConfirmModal={closeConfirmModal}
+                    itemFullName={classroom.classSubject}
+                    itemId={classroom._id}
+                    deleteMsg={
+                      "Are you sure you want to delete this classroom? This cannot be undone."
+                    }
+                    removeItemFromSystem={handleDeleteClassroom}
+                    inputNeeded={false}
+                  />
                 </article>
               ))
             ) : (
@@ -155,6 +177,7 @@ const TeacherHome = () => {
             </button>
           </div>
         </div>
+
         {/* <div className="w-[35%] lg:order-first"> */}
         <aside className="bottom-0 fixed w-screen lg:inset-y-0 lg:left-0 lg:order-first lg:w-44 ">
           <Nav setIsEditMode={setIsEditMode} teacherId={userData._id} />

--- a/client/src/pages/teacher/TeacherHome.jsx
+++ b/client/src/pages/teacher/TeacherHome.jsx
@@ -18,12 +18,15 @@ import TeacherNavbar from "../../components/Navbar/TeacherNavbar.jsx";
 import Nav from "../../components/Navbar/Nav.jsx";
 import withAuth from "../../hoc/withAuth.js";
 import ConfirmationModal from "../../components/TeacherView/ConfirmationModal.jsx";
+import { handleError, handleSuccess } from "../../utils/toastHandling";
 
 const TeacherHome = () => {
   const { userData } = useUser();
   const [classroomsData, setClassroomsData] = useState([]);
   const [isEditMode, setIsEditMode] = useState(false);
   const [selectedClassroom, setSelectedClassroom] = useState(null);
+  const [toastShown, setToastShown] = useState(false);
+
   const modalRefs = useRef({});
 
   const openConfirmModal = (classroomId) => {
@@ -63,13 +66,15 @@ const TeacherHome = () => {
     fetchTeacherData();
   }, [userData]);
 
-  const handleDeleteClassroom = async (classroomId) => {
+  const handleDeleteClassroom = async (classroomId, classroomSubject) => {
     try {
       await deleteClassroom(userData._id, classroomId);
       setClassroomsData((prevData) =>
         prevData.filter((item) => item.classroom._id !== classroomId)
       );
       closeConfirmModal(classroomId);
+      handleSuccess(`${classroomSubject} deleted successfully!`);
+      setToastShown(true);
     } catch (error) {
       console.error(error);
     }
@@ -164,9 +169,7 @@ const TeacherHome = () => {
                     closeConfirmModal={() => closeConfirmModal(classroom._id)}
                     itemFullName={classroom.classSubject}
                     itemId={classroom._id}
-                    deleteMsg={
-                      "Are you sure you want to delete this classroom? This cannot be undone."
-                    }
+                    deleteMsg={`Are you sure you want to delete ${classroom.classSubject}? This cannot be undone.`}
                     removeItemFromSystem={handleDeleteClassroom}
                     inputNeeded={false}
                   />

--- a/client/src/pages/teacher/TeacherHome.jsx
+++ b/client/src/pages/teacher/TeacherHome.jsx
@@ -26,7 +26,7 @@ const TeacherHome = () => {
   const [isEditMode, setIsEditMode] = useState(false);
   const [selectedClassroom, setSelectedClassroom] = useState(null);
   const [toastShown, setToastShown] = useState(false);
-
+  // this is a test
   const modalRefs = useRef({});
 
   const openConfirmModal = (classroomId) => {

--- a/client/src/pages/teacher/studentProfile/StudentProfile.jsx
+++ b/client/src/pages/teacher/studentProfile/StudentProfile.jsx
@@ -831,6 +831,7 @@ const StudentProfile = () => {
           inputValue={inputValue}
           setInputValue={setInputValue}
           removeItemFromSystem={deleteOneStudent}
+          inputNeeded={true}
         />
         <div className="bottom-0 fixed w-screen lg:inset-y-0 lg:left-0 lg:order-first lg:w-44 ">
           <Nav teacherId={teacherId} classroomId={classroomId} />


### PR DESCRIPTION
This adds the confirmation modal when deleting classrooms on the dashboard page, and when removing students from the classroom in the class list page. A toast also pops up for each removal.
The loading screen shows now when loading the dashboard screen. Might put a threshold later for it to appear. There is a minimum amount of time the loading screen shows for from the login screen, because otherwise it kind of disorients the user when it flashes on the screen. Can remove or set up something different in the future

